### PR TITLE
Rustで１文字列を取得する関数実装。レキサーをそれぞれ振り分ける関数実装

### DIFF
--- a/src/worker_thread/worker.rs
+++ b/src/worker_thread/worker.rs
@@ -1,3 +1,5 @@
+use nix::sys::statvfs::vfs::NOATIME;
+
 
 enum Token {
     Word, //単語
@@ -39,15 +41,32 @@ pub fn try_revc(cmd: &str) {
 
 ///
 impl Lexer {
-    ///１つ進めるだけの関数
+    ///入力文字列の現在地から１文字づつ読む関数
     fn next_char(&mut self, cmd: &str) -> Option<char> {
-        if self.position >= cmd.len() {
-            return  None;
-        }
-
-        let ch = cmd[self.position];
-        self.position += 1;
-
+        let mut iter = cmd[self.position..].chars();
+        let  ch = iter.next()?;
+        self.position += ch.len_utf8();
         Some(ch)
+    }
+
+    ///レキサーを格状態に振り分ける関数
+    fn Lexar_allocation(&mut self, cmd: &str) -> Result<(), String> {
+        //文字があるのかないのかをチェック
+        let ch = match self.next_char(cmd) {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+
+        //それぞれのレキサー状態に関数に振り分ける
+        match self._state {
+            LexerState::Normal => Lexer_nomal(ch, cmd),
+            LexerState::InWord => Lexer_inword(ch, cmd),
+            LexerState::AfterEscape => Lexer_afterescape(ch, cmd),
+            LexerState::InNextRedirect => Lexer_innextredirect(ch, cmd),
+            LexerState::InNextAnd => Lexer_innextand(ch, cmd),
+            LexerState::InNextOr => Lexer_innextor(ch, cmd),
+            LexerState::InSingleQuote => Lexer_insinglequote(ch, cmd),
+            LexerState::InDoubleQuote => Lexer_indoublequote(ch, cmd),
+        }
     }
 }


### PR DESCRIPTION
文字列を１文字とってポジションを進める関数。
文字があるかないかチェックしてあるならそれぞれのレキサー状態に振り分ける関数